### PR TITLE
Emit 'disconnect' event after close

### DIFF
--- a/lib/MockNatsClient.js
+++ b/lib/MockNatsClient.js
@@ -29,6 +29,8 @@ class MockNatsClient extends EventEmitter {
 	close() {
 		this.subs = [];
 		this.connected = false;
+
+		process.nextTick(() => this.emit('disconnect'));
 	}
 
 	/**

--- a/spec/MockNatsClient.spec.js
+++ b/spec/MockNatsClient.spec.js
@@ -18,6 +18,20 @@ describe("MockNatsClient", () => {
 		
 		client.connect();	
 	});
+	
+	it("should emit 'disconnect' event on close", (done) => {
+		client.on("connect", () => {
+			expect(client.connected).toBe(true);		
+			client.close();
+		});
+		
+		client.on("disconnect", () => {
+			expect(client.connected).toBe(false);
+			done();
+		});
+		
+		client.connect();	
+	});
 
 	it("should subscribe and publish to 'foo'", (done) => {
 		client.subscribe("foo", {}, (msg, replyTo, actualSubject) => {


### PR DESCRIPTION
The official client emits a 'disconnect' event after closing the connection, which we use in our app. This PR fixes that.