### PR TITLE
Add editorconfig, jshint task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; editorconfig.org
+root = true
+charset= utf8
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/MockNatsClient.js
+++ b/lib/MockNatsClient.js
@@ -10,9 +10,9 @@ class MockNatsClient extends EventEmitter {
 	}
 
 	/**
-	 * Mock connect. Will not do anything except from setting 
+	 * Mock connect. Will not do anything except from setting
 	 * property `connected` to true and emit `connect` event.
-	 * 	
+	 *
 	 * @param  {object} opts
 	 */
 	connect(opts) {
@@ -24,7 +24,7 @@ class MockNatsClient extends EventEmitter {
 	}
 
 	/**
-	 * Mock close. Will empty subscriptions and set `connected` to false.	 
+	 * Mock close. Will empty subscriptions and set `connected` to false.
 	 */
 	close() {
 		this.subs = [];
@@ -35,10 +35,10 @@ class MockNatsClient extends EventEmitter {
 
 	/**
 	 * Subscribe to subject.
-	 * 
+	 *
 	 * @param  {string}   subject       subject to subscribe to
 	 * @param  {mixed}    opts          options or callback
-	 * @param  {Function} cb            
+	 * @param  {Function} cb
 	 * @return {string}                 subject id (sid)
 	 */
 	subscribe(subject, opts, cb /* (msg, replyTo, subject) */) {
@@ -65,13 +65,13 @@ class MockNatsClient extends EventEmitter {
 
 		return sid;
 	}
-	
+
 	/**
 	 * Publish message to subject.
-	 * 
+	 *
 	 * @param  {string} subject
 	 * @param  {string} message
-	 * @param  {string} replyTo subject	 
+	 * @param  {string} replyTo subject
 	 */
 	publish(subject, message, replyTo) {
 		const subs = this._findSubscribesBySubject(subject);
@@ -79,60 +79,60 @@ class MockNatsClient extends EventEmitter {
 		subs.forEach(sub => {
 			if (sub) {
 				sub.received++;
-				
+
 				if (sub.timeout && sub.received >= sub.expected) {
 					clearTimeout(sub.timeout);
 					sub.timeout = null;
 				}
 
-				sub.cb(message, replyTo, subject);			
-			} 			
+				sub.cb(message, replyTo, subject);
+			}
 		});
 
 	}
 
 	/**
 	 * Remove existing subscription by sid.
-	 * 
-	 * @param  {string} sid 	 
+	 *
+	 * @param  {string} sid
 	 */
 	unsubscribe(sid) {
-		// TODO: Add support for auto-unsubscribe after MAX_WANTED messages received		
+		// TODO: Add support for auto-unsubscribe after MAX_WANTED messages received
 		const subToRemove = this._findSubscribeBySid(sid);
 
-		if (subToRemove) {			
+		if (subToRemove) {
 			this.subs.splice(this.subs.indexOf(subToRemove), 1);
-		}		
+		}
 	}
-	
+
 	/**
 	 * Invoke timeout callback if subscription has not received
 	 * expected number of message during given timeout (ms).
-	 * 
-	 * @param  {string}   sid     
+	 *
+	 * @param  {string}   sid
 	 * @param  {number}   timeout  in ms
 	 * @param  {number}   expected number of messages to receive
-	 * @param  {Function} cb 	 
+	 * @param  {Function} cb
 	 */
 	timeout(sid, timeout, expected, cb = () => {}) {
 		let sub = this._findSubscribeBySid(sid);
 
 		if (sub) {
-			sub.expected = expected;				
+			sub.expected = expected;
 			sub.timeout = setTimeout(() => {
 				cb(sid);
-			}, timeout);			
+			}, timeout);
 		}
 	}
 
-	_findSubscribesBySubject(subject) {		
+	_findSubscribesBySubject(subject) {
 		let matches = this.subs.filter(sub => utils.matchSubject(subject, sub.subject));
 
 		// Pick one subscribe from each queue group plus all subscriptions
-		// that does not have any queue group set	
+		// that does not have any queue group set
 		let onePerQueue = {};
 
-		matches.forEach(sub => {			
+		matches.forEach(sub => {
 			onePerQueue[sub.queue || uuid.v4()] = sub;
 		});
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ utils.matchSubject = (subject, pattern) => {
 
 	let subjectSplit = subject.split(".");
 	let patternSplit = pattern.split(".");
-	
+
 	let match = true;
 	let i = 0;
 	let mostDetailedSplit = subjectSplit.length >= patternSplit.length ? subjectSplit : patternSplit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-nats-client",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,13 +11,23 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
       }
     },
     "colors": {
@@ -30,6 +40,82 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
     "exit": {
@@ -58,6 +144,19 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -74,21 +173,27 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "jasmine": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
-      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
+      "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
         "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
+        "jasmine-core": "2.99.1"
       }
     },
     "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "jasmine-spec-reporter": {
@@ -100,13 +205,35 @@
         "colors": "1.1.2"
       }
     },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      }
+    },
+    "lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "ms": {
@@ -129,10 +256,40 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "mock-nats-client",
   "version": "0.0.4",
   "scripts": {
-    "test": "node ./spec/support/jasmine-runner.js"
+    "test": "node ./spec/support/jasmine-runner.js",
+    "posttest": "npm run lint",
+    "lint": "jshint lib spec"
   },
   "dependencies": {
     "ms": "^0.7.2",
@@ -10,7 +12,8 @@
   },
   "devDependencies": {
     "jasmine": "^2.5.2",
-    "jasmine-spec-reporter": "^2.7.0"
+    "jasmine-spec-reporter": "^2.7.0",
+    "jshint": "^2.9.5"
   },
   "author": "Joel Söderström <joel@frostdigital.se>",
   "license": "MIT",

--- a/spec/MockNatsClient.spec.js
+++ b/spec/MockNatsClient.spec.js
@@ -3,34 +3,34 @@ const MockNatsClient = require("../lib/MockNatsClient");
 describe("MockNatsClient", () => {
 
 	let client;
-	
+
 	beforeEach(() => {
 		client = new MockNatsClient();
 	});
-	
+
 	it("should connect and close", (done) => {
 		client.on("connect", () => {
-			expect(client.connected).toBe(true);		
-			client.close();			
+			expect(client.connected).toBe(true);
+			client.close();
 			expect(client.connected).toBe(false);
 			done();
 		});
-		
-		client.connect();	
+
+		client.connect();
 	});
-	
+
 	it("should emit 'disconnect' event on close", (done) => {
 		client.on("connect", () => {
-			expect(client.connected).toBe(true);		
+			expect(client.connected).toBe(true);
 			client.close();
 		});
-		
+
 		client.on("disconnect", () => {
 			expect(client.connected).toBe(false);
 			done();
 		});
-		
-		client.connect();	
+
+		client.connect();
 	});
 
 	it("should subscribe and publish to 'foo'", (done) => {
@@ -84,21 +84,21 @@ describe("MockNatsClient", () => {
 			expect(oSid).toBe(sid);
 			done();
 		});
-		
+
 	});
 
 	it("should not timeout if receiving expected num of messages", (done) => {
 
 		const sid = client.subscribe("foo", {}, (msg, replyTo, actualSubject) => {});
-		
+
 		client.timeout(sid, 100, 2, (oSid) => {
-			done.fail()
+			done.fail();
 		});
-		
+
 		client.publish("foo", "message");
-		client.publish("foo", "message");		
-		
-		setTimeout(() => {			
+		client.publish("foo", "message");
+
+		setTimeout(() => {
 			done();
 		}, 200);
 	});
@@ -108,15 +108,15 @@ describe("MockNatsClient", () => {
 		function count() {
 			numInvocations++;
 		}
-		
+
 		client.subscribe("foo", { queue: "q1" }, count);
 		client.subscribe("foo", { queue: "q1" }, count);
 		client.subscribe("foo", { queue: "q2" }, count);
 		client.subscribe("foo", { queue: "q2" }, count);
 		client.subscribe("foo", {}, count);
-		
-		client.publish("foo", "message");		
-		
+
+		client.publish("foo", "message");
+
 		setTimeout(() => {
 			expect(numInvocations).toBe(3);
 			done();


### PR DESCRIPTION
Hi,

This PR adds an editorconfig which should match the tab-style indentation used, and also ensures that trailing whitespace is trimmed (this was a bit inconsistent, so I've fixed the trailing whitespace where I could find it).

There was a jshint config in the repository, but no task for it, so I added a post-test hook to run it as well. 
