### PR TITLE
Respect `json`, `preserveBuffers` flags

### DIFF
--- a/lib/MockNatsClient.js
+++ b/lib/MockNatsClient.js
@@ -4,9 +4,11 @@ const EventEmitter = require("events");
 
 class MockNatsClient extends EventEmitter {
 
-	constructor() {
+	constructor(opts = {}) {
 		super();
 		this.subs = [];
+		this.useJson = 'json' in opts ? opts.json : false;
+		this.preserveBuffers = 'preserveBuffers' in opts ? opts.preserveBuffers : false;
 	}
 
 	/**
@@ -74,6 +76,18 @@ class MockNatsClient extends EventEmitter {
 	 * @param  {string} replyTo subject
 	 */
 	publish(subject, message, replyTo) {
+		// Messages are published as buffers
+		const content = this.useJson ? JSON.stringify(message) : message;
+		const payload = Buffer.isBuffer(content) ? content : Buffer.from(content);
+
+		// Messages can be delivers as buffers or strings, and also JSON decoded
+		let delivery = payload;
+		if (this.useJson) {
+			delivery = JSON.parse(delivery);
+		} else if (!this.preserveBuffers) {
+			delivery = payload.toString();
+		}
+
 		const subs = this._findSubscribesBySubject(subject);
 
 		subs.forEach(sub => {
@@ -85,7 +99,7 @@ class MockNatsClient extends EventEmitter {
 					sub.timeout = null;
 				}
 
-				sub.cb(JSON.parse(JSON.stringify(message)), replyTo, subject);
+				sub.cb(delivery, replyTo, subject);
 			}
 		});
 

--- a/spec/MockNatsClient.spec.js
+++ b/spec/MockNatsClient.spec.js
@@ -5,7 +5,7 @@ describe("MockNatsClient", () => {
 	let client;
 
 	beforeEach(() => {
-		client = new MockNatsClient();
+		client = new MockNatsClient({json: true});
 	});
 
 	it("should connect and close", (done) => {
@@ -79,6 +79,42 @@ describe("MockNatsClient", () => {
 		client.publish("foo", { date: new Date(dateString) }, "replyTo");
 	});
 
+	it("should not json encode/decode by default", (done) => {
+		client = new MockNatsClient();
+		client.subscribe("foo", {}, (msg, replyTo, actualSubject) => {
+			expect(msg).toBe("abc123");
+			expect(replyTo).toBe("replyTo");
+			expect(actualSubject).toBe("foo");
+			done();
+		});
+
+		client.publish("foo", Buffer.from("abc123"), "replyTo");
+	});
+
+	it("should not json encode/decode when setting json to false", (done) => {
+		client = new MockNatsClient({json: false});
+		client.subscribe("foo", {}, (msg, replyTo, actualSubject) => {
+			expect(msg).toBe("abc123");
+			expect(replyTo).toBe("replyTo");
+			expect(actualSubject).toBe("foo");
+			done();
+		});
+
+		client.publish("foo", Buffer.from("abc123"), "replyTo");
+	});
+
+	it("should preserve raw buffers if told to", (done) => {
+		client = new MockNatsClient({preserveBuffers: true});
+		client.subscribe("foo", {}, (msg, replyTo, actualSubject) => {
+			expect(Buffer.isBuffer(msg)).toBe(true);
+			expect(msg.toString()).toBe("abc123");
+			expect(replyTo).toBe("replyTo");
+			expect(actualSubject).toBe("foo");
+			done();
+		});
+
+		client.publish("foo", Buffer.from("abc123"), "replyTo");
+	});
 
 	it("should unsubscribe", () => {
 		const sid = client.subscribe("foo", {}, (msg, replyTo, actualSubject) => { });


### PR DESCRIPTION
Currently, the mock client doesn't follow the same rules as the official client in two important areas:

- The official client has `json` set to `false` by default. Previously the mocked client would just pass through the message as-is, but it now JSON encodes and decodes the value. This creates a mismatch in behavior.
- The official client has a `preserveBuffers` option, but this is not respected. Because of the JSON-encoding/decoding, this breaks some applications.

This PR replicates the official client behavior in terms of serialization/deserialization.